### PR TITLE
Use mineprefs in Pivotal-Preferences-RubyMine to generate directories

### DIFF
--- a/attributes/preferences.rb
+++ b/attributes/preferences.rb
@@ -6,10 +6,3 @@ default['sprout']['rubymine']['preferences']['revision'] = 'master'
 
 default['sprout']['rubymine']['preferences']['install_dir'] =
   "#{node['sprout']['home']}/Library/Preferences/RubyMine60"
-
-default['sprout']['rubymine']['preferences']['dirs_to_link'] = %w(
-  codestyles
-  keymaps
-  options
-  templates
-)

--- a/recipes/preferences.rb
+++ b/recipes/preferences.rb
@@ -9,26 +9,8 @@ git preferences['clone_dir'] do
   user node['current_user']
 end
 
-directory preferences['install_dir'] do
-  owner node['current_user']
-  mode '0755'
-  action :create
-end
-
-backup_time = Time.now.utc.iso8601
-
-preferences['dirs_to_link'].each do |dir_to_link|
-  execute "Backup #{::File.join(preferences['install_dir'], dir_to_link)}" do
-    command <<-CMD
-              mv \
-                #{::File.join(preferences['install_dir'], dir_to_link)} \
-                #{::File.join(preferences['install_dir'], dir_to_link)}.bak.#{backup_time}
-    CMD
-    only_if { File.exist?(File.join(preferences['install_dir'], dir_to_link)) }
-  end
-
-  link ::File.join(preferences['install_dir'], dir_to_link) do
-    to ::File.join(preferences['clone_dir'], 'RubyMineXX', dir_to_link)
-    owner node['current_user']
-  end
+execute './mineprefs install' do
+  cwd preferences['clone_dir']
+  user node['current_user']
+  environment('TARGET_DIR' => preferences['install_dir'])
 end


### PR DESCRIPTION
Per @moonmaster9000 we've made the Pivotal-Preferences-RubyMine mineprefs script create the necessary directories for installing RubyMine preferences, pending https://github.com/pivotal/Pivotal-Preferences-RubyMine/pull/27.  This PR would move all the preferences behavior previously in this recipe to the mineprefs script.
